### PR TITLE
hotfix by Parham: Previous password check procedure fixed

### DIFF
--- a/src/main/java/com/CodeMasters_9000/dao_CodeMasters_9000/ServerDao.java
+++ b/src/main/java/com/CodeMasters_9000/dao_CodeMasters_9000/ServerDao.java
@@ -55,9 +55,15 @@ public class ServerDao {
 	
 	
 	public boolean setPass(String Id,String oldPass , String newPass, String confirmPass) {
+		boolean flag = false;
+		List<Server> serverList = getAllServers();
 		
-		
-		if (newPass.equals(confirmPass)) {
+		for(Server server : serverList) {
+			if(server.getPassword().equals(oldPass)) {
+				flag = true;
+			}
+		}
+		if (newPass.equals(confirmPass) && flag) {
 			
 			return jdbcTemplate.update(SQL_SETPASSWORD, newPass, Id) > 0;
 		}else 


### PR DESCRIPTION
We had to check the "previous password" entered with the password that is already on database. Feature failed to do that so I fixed it.